### PR TITLE
Split OpenAPI JSON for Donation Types

### DIFF
--- a/SeparatedJson/DonationTypeTests.cs
+++ b/SeparatedJson/DonationTypeTests.cs
@@ -1,0 +1,109 @@
+using NUnit.Framework;
+using RestSharp;
+using System.Net;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace RestApiNUnitTests
+{
+    [TestFixture]
+    public class DonationTypeTests
+    {
+        private RestClient client;
+        private const string BaseUrl = "http://api.example.com"; // Replace with actual API URL
+
+        [SetUp]
+        public void Setup()
+        {
+            client = new RestClient(BaseUrl);
+        }
+
+        [Test]
+        public async Task GetAllDonationTypes_ReturnsSuccessStatusCode()
+        {
+            var request = new RestRequest("/api/v1/donation/types", Method.GET);
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public async Task GetAllDonationTypes_ReturnsListOfDonationTypes()
+        {
+            var request = new RestRequest("/api/v1/donation/types", Method.GET);
+            var response = await client.ExecuteAsync(request);
+
+            var donationTypes = JsonConvert.DeserializeObject<List<DonationTypeDto>>(response.Content);
+            Assert.That(donationTypes, Is.Not.Null);
+            Assert.That(donationTypes, Is.Not.Empty);
+        }
+
+        [Test]
+        public async Task AddDonationType_ReturnsSuccessStatusCode()
+        {
+            var newDonationType = new DonationTypeDto
+            {
+                Name = "Test Donation Type",
+                ShortDescription = "Short description",
+                LongDescription = "Long description",
+                IconData = "base64encodedstring",
+                HeaderColor = "#FFFFFF"
+            };
+
+            var request = new RestRequest("/api/v1/donation/types", Method.POST);
+            request.AddJsonBody(newDonationType);
+
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public async Task EditDonationType_ReturnsSuccessStatusCode()
+        {
+            var updatedDonationType = new DonationTypeDto
+            {
+                Id = 1, // Assume this ID exists
+                Name = "Updated Donation Type",
+                ShortDescription = "Updated short description",
+                LongDescription = "Updated long description",
+                IconData = "updatedbase64encodedstring",
+                HeaderColor = "#000000"
+            };
+
+            var request = new RestRequest("/api/v1/donation/types", Method.PUT);
+            request.AddJsonBody(updatedDonationType);
+
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public async Task DeleteDonationType_ReturnsSuccessStatusCode()
+        {
+            int donationTypeIdToDelete = 1; // Assume this ID exists
+
+            var request = new RestRequest($"/api/v1/donation/types/{donationTypeIdToDelete}", Method.DELETE);
+
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+    }
+
+    public class DonationTypeDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ShortDescription { get; set; }
+        public string LongDescription { get; set; }
+        public string IconData { get; set; }
+        public string CreateDate { get; set; }
+        public string CreatedBy { get; set; }
+        public string UpdateDate { get; set; }
+        public string LastUpdatedBy { get; set; }
+        public string HeaderColor { get; set; }
+    }
+}

--- a/SeparatedJson/api_v1_donation_types.json
+++ b/SeparatedJson/api_v1_donation_types.json
@@ -1,0 +1,395 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "DonorApp API",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/donation/types": {
+      "get": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Gets all donation types",
+        "responses": {
+          "200": {
+            "description": "Collection of donation types.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DonationTypeDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DonationTypeDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DonationTypeDto"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Allows you to add a new donation type.",
+        "requestBody": {
+          "description": "The DonorApp.Services.DTO.DonationTypeDto instance that represents a donation type to add.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Donation type successfully added.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Allows to edit a donation type.",
+        "requestBody": {
+          "description": "The DonorApp.Services.DTO.DonationTypeDto instance that represents a donation type to edit.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Donation type successfully edited.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/donation/types/{id}": {
+      "delete": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Allows to delete a donation type.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The M:DonorAppCore.Controllers.DonationTypesController.DeleteDonationType(System.Int32) instance that represents a donation type id for delete.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Donation type successfully deleted.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationTypeDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationTypeDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationTypeDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ContentResult": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "contentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "statusCode": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DonationTypeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "shortDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "longDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconData": {
+            "type": "string",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "updateDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastUpdatedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "headerColor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request contains the following changes:

1. Created a new file 'SeparatedJson/api_v1_donation_types.json' with the OpenAPI specification for the donation types endpoints.
2. Added 'SeparatedJson/DonationTypeTests.cs' with NUnit tests for the donation types API.

These changes separate the donation types API documentation and add corresponding tests, improving the maintainability and testability of the API.