### PR TITLE
Split OpenAPI JSON for /api/v1/donation/types endpoint

### DIFF
--- a/SeparatedJson/DonationTypeTests.cs
+++ b/SeparatedJson/DonationTypeTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using System.Net;
+using System.Threading.Tasks;
+using RestSharp;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace RestApiNUnitTests
+{
+    [TestFixture]
+    public class DonationTypeTests
+    {
+        private RestClient client;
+        private const string BaseUrl = "https://api.example.com";
+
+        [SetUp]
+        public void Setup()
+        {
+            client = new RestClient(BaseUrl);
+        }
+
+        [Test]
+        public async Task GetAllDonationTypes_ReturnsSuccessStatusCode()
+        {
+            var request = new RestRequest("/api/v1/donation/types", Method.GET);
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public async Task GetAllDonationTypes_ReturnsListOfDonationTypes()
+        {
+            var request = new RestRequest("/api/v1/donation/types", Method.GET);
+            var response = await client.ExecuteAsync(request);
+
+            var donationTypes = JsonConvert.DeserializeObject<List<DonationTypeDto>>(response.Content);
+            Assert.That(donationTypes, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task AddDonationType_ReturnsSuccessStatusCode()
+        {
+            var newDonationType = new DonationTypeDto
+            {
+                Name = "Test Donation Type",
+                ShortDescription = "Short description",
+                LongDescription = "Long description"
+            };
+
+            var request = new RestRequest("/api/v1/donation/types", Method.POST)
+                .AddJsonBody(newDonationType);
+
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public async Task EditDonationType_ReturnsSuccessStatusCode()
+        {
+            var updatedDonationType = new DonationTypeDto
+            {
+                Id = 1, // Assuming this ID exists
+                Name = "Updated Donation Type",
+                ShortDescription = "Updated short description",
+                LongDescription = "Updated long description"
+            };
+
+            var request = new RestRequest("/api/v1/donation/types", Method.PUT)
+                .AddJsonBody(updatedDonationType);
+
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public async Task DeleteDonationType_ReturnsSuccessStatusCode()
+        {
+            int donationTypeIdToDelete = 1; // Assuming this ID exists
+
+            var request = new RestRequest($"/api/v1/donation/types/{donationTypeIdToDelete}", Method.DELETE);
+
+            var response = await client.ExecuteAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+    }
+
+    public class DonationTypeDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ShortDescription { get; set; }
+        public string LongDescription { get; set; }
+        public string IconData { get; set; }
+        public System.DateTime CreateDate { get; set; }
+        public string CreatedBy { get; set; }
+        public System.DateTime UpdateDate { get; set; }
+        public string LastUpdatedBy { get; set; }
+        public string HeaderColor { get; set; }
+    }
+}

--- a/SeparatedJson/api_v1_donation_types.json
+++ b/SeparatedJson/api_v1_donation_types.json
@@ -1,0 +1,395 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "DonorApp API",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/donation/types": {
+      "get": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Gets all donation types",
+        "responses": {
+          "200": {
+            "description": "Collection of donation types.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DonationTypeDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DonationTypeDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DonationTypeDto"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Allows you to add a new donation type.",
+        "requestBody": {
+          "description": "The DonorApp.Services.DTO.DonationTypeDto instance that represents a donation type to add.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Donation type successfully added.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Allows to edit a donation type.",
+        "requestBody": {
+          "description": "The DonorApp.Services.DTO.DonationTypeDto instance that represents a donation type to edit.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DonationTypeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Donation type successfully edited.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/donation/types/{id}": {
+      "delete": {
+        "tags": [
+          "DonationTypes"
+        ],
+        "summary": "Allows to delete a donation type.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The M:DonorAppCore.Controllers.DonationTypesController.DeleteDonationType(System.Int32) instance that represents a donation type id for delete.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Donation type successfully deleted.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationTypeDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationTypeDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DonationTypeDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error! See json response for details.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ContentResult": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "contentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "statusCode": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DonationTypeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "shortDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "longDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconData": {
+            "type": "string",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "updateDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastUpdatedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "headerColor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request contains the following changes:
1. Created a new JSON file 'api_v1_donation_types.json' in the SeparatedJson directory, which includes the OpenAPI specification for the /api/v1/donation/types endpoint.
2. Added a new test file 'DonationTypeTests.cs' in the SeparatedJson directory with unit tests for the donation types API endpoints.

These changes aim to improve the organization of our API documentation and increase test coverage for the donation types functionality.